### PR TITLE
74 none of the links work on GitHub pages

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,6 +1,5 @@
 User-agent: Googlebot
 Allow: /
-Allow: /templates
 User-agent: DuckDuckBot
-Allow: /templates
+Allow: /
 Sitemap: https://jidone7061.github.io/mywebclass-simulation/sitemap.xml

--- a/src/sitemap.html
+++ b/src/sitemap.html
@@ -7,7 +7,7 @@
 	<h1>Site Map</h1>
 	<ul>
 		<li><a href="https://jidone7061.github.io/mywebclass-simulation/">MyWebClass Simulation</a></li>
-        <li><a href="https://jidone7061.github.io/mywebclass-simulation/templates/template-content.html">Template Content</a></li>
+        <li><a href="https://jidone7061.github.io/mywebclass-simulation/template-content.html">Template Content</a></li>
 		<li><a href="https://jidone7061.github.io/mywebclass-simulation/privacy.html">Privacy Policy</a></li>
 	</ul>
 </body>

--- a/src/sitemap.txt
+++ b/src/sitemap.txt
@@ -1,3 +1,3 @@
 https://jidone7061.github.io/mywebclass-simulation
-https://jidone7061.github.io/mywebclass-simulation/templates/template-content.html
+https://jidone7061.github.io/mywebclass-simulation/template-content.html
 https://jidone7061.github.io/mywebclass-simulation/privacy.html

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
-      <loc>https://jidone7061.github.io/mywebclass-simulation/templates/template-content.html</loc>
+      <loc>https://jidone7061.github.io/mywebclass-simulation/template-content.html</loc>
       <lastmod>2023-03-19</lastmod>
       <changefreq>weekly</changefreq>
       <priority>0.8</priority>


### PR DESCRIPTION
After removing the /templates directory, there are changes made to sitemap and robots.txt files to point to the new URL. The change seems simple enough but since those are your contributions, please double check I did it correctly